### PR TITLE
add open api

### DIFF
--- a/frontapi/build.gradle
+++ b/frontapi/build.gradle
@@ -29,6 +29,7 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0'
 }
 
 tasks.named('test') {

--- a/frontapi/src/main/java/com/harmoni/frontapi/configuration/OpenApiConfig.java
+++ b/frontapi/src/main/java/com/harmoni/frontapi/configuration/OpenApiConfig.java
@@ -1,0 +1,24 @@
+package com.harmoni.frontapi.configuration;
+
+import io.swagger.v3.oas.models.ExternalDocumentation;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.info.License;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+
+    @Bean
+    public OpenAPI OpenAPISpec() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("frontapi")
+                        .version("v1.0")
+                        .description("this is swagger page for frontapi")
+                        .license(new License().name("Apache 2.0").url("http://springdoc.org")))
+                .externalDocs(new ExternalDocumentation()
+                        .description("Project Documentation"));
+    }
+}


### PR DESCRIPTION
- make open api available to assist development
- accessible on `http://localhost:8080/swagger-ui/index.html`
- sample
   <img width="1488" alt="image" src="https://github.com/user-attachments/assets/2dcaa460-fe44-4354-8f80-099fdd02d03c" />


