### PR TITLE
relocate dao/module to respective module root

### DIFF
--- a/frontapi/src/main/java/com/harmoni/frontapi/main/customer/controller/CustomerController.java
+++ b/frontapi/src/main/java/com/harmoni/frontapi/main/customer/controller/CustomerController.java
@@ -3,7 +3,7 @@ package com.harmoni.frontapi.main.customer.controller;
 import com.harmoni.frontapi.main.common.FrontApiGenericResponse;
 import com.harmoni.frontapi.main.common.ResponsePayload;
 import com.harmoni.frontapi.main.customer.service.CustomerService;
-import com.harmoni.frontapi.main.customer.service.model.Customer;
+import com.harmoni.frontapi.main.customer.model.Customer;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;

--- a/frontapi/src/main/java/com/harmoni/frontapi/main/customer/dao/CustomerDao.java
+++ b/frontapi/src/main/java/com/harmoni/frontapi/main/customer/dao/CustomerDao.java
@@ -1,6 +1,6 @@
-package com.harmoni.frontapi.main.customer.service.dao;
+package com.harmoni.frontapi.main.customer.dao;
 
-import com.harmoni.frontapi.main.customer.service.model.Customer;
+import com.harmoni.frontapi.main.customer.model.Customer;
 
 import java.util.List;
 import java.util.UUID;

--- a/frontapi/src/main/java/com/harmoni/frontapi/main/customer/dao/DevCustomerDaoService.java
+++ b/frontapi/src/main/java/com/harmoni/frontapi/main/customer/dao/DevCustomerDaoService.java
@@ -1,6 +1,6 @@
-package com.harmoni.frontapi.main.customer.service.dao;
+package com.harmoni.frontapi.main.customer.dao;
 
-import com.harmoni.frontapi.main.customer.service.model.Customer;
+import com.harmoni.frontapi.main.customer.model.Customer;
 import org.springframework.stereotype.Repository;
 
 import java.util.ArrayList;

--- a/frontapi/src/main/java/com/harmoni/frontapi/main/customer/model/Customer.java
+++ b/frontapi/src/main/java/com/harmoni/frontapi/main/customer/model/Customer.java
@@ -1,4 +1,4 @@
-package com.harmoni.frontapi.main.customer.service.model;
+package com.harmoni.frontapi.main.customer.model;
 
 import lombok.*;
 

--- a/frontapi/src/main/java/com/harmoni/frontapi/main/customer/service/CustomerService.java
+++ b/frontapi/src/main/java/com/harmoni/frontapi/main/customer/service/CustomerService.java
@@ -2,8 +2,8 @@ package com.harmoni.frontapi.main.customer.service;
 
 import com.harmoni.frontapi.main.common.FrontApiGenericResponse;
 import com.harmoni.frontapi.main.common.ResponsePayload;
-import com.harmoni.frontapi.main.customer.service.dao.CustomerDao;
-import com.harmoni.frontapi.main.customer.service.model.Customer;
+import com.harmoni.frontapi.main.customer.dao.CustomerDao;
+import com.harmoni.frontapi.main.customer.model.Customer;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 

--- a/frontapi/src/main/java/com/harmoni/frontapi/main/product/controller/ProductController.java
+++ b/frontapi/src/main/java/com/harmoni/frontapi/main/product/controller/ProductController.java
@@ -3,7 +3,7 @@ package com.harmoni.frontapi.main.product.controller;
 import com.harmoni.frontapi.main.common.FrontApiGenericResponse;
 import com.harmoni.frontapi.main.common.ResponsePayload;
 import com.harmoni.frontapi.main.product.service.ProductService;
-import com.harmoni.frontapi.main.product.service.model.Product;
+import com.harmoni.frontapi.main.product.model.Product;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/frontapi/src/main/java/com/harmoni/frontapi/main/product/dao/DevProductDaoService.java
+++ b/frontapi/src/main/java/com/harmoni/frontapi/main/product/dao/DevProductDaoService.java
@@ -1,6 +1,6 @@
-package com.harmoni.frontapi.main.product.service.dao;
+package com.harmoni.frontapi.main.product.dao;
 
-import com.harmoni.frontapi.main.product.service.model.Product;
+import com.harmoni.frontapi.main.product.model.Product;
 import org.springframework.stereotype.Repository;
 
 import java.util.ArrayList;

--- a/frontapi/src/main/java/com/harmoni/frontapi/main/product/dao/ProductDao.java
+++ b/frontapi/src/main/java/com/harmoni/frontapi/main/product/dao/ProductDao.java
@@ -1,6 +1,6 @@
-package com.harmoni.frontapi.main.product.service.dao;
+package com.harmoni.frontapi.main.product.dao;
 
-import com.harmoni.frontapi.main.product.service.model.Product;
+import com.harmoni.frontapi.main.product.model.Product;
 
 import java.util.List;
 import java.util.UUID;

--- a/frontapi/src/main/java/com/harmoni/frontapi/main/product/model/Product.java
+++ b/frontapi/src/main/java/com/harmoni/frontapi/main/product/model/Product.java
@@ -1,4 +1,4 @@
-package com.harmoni.frontapi.main.product.service.model;
+package com.harmoni.frontapi.main.product.model;
 
 import lombok.*;
 

--- a/frontapi/src/main/java/com/harmoni/frontapi/main/product/service/ProductService.java
+++ b/frontapi/src/main/java/com/harmoni/frontapi/main/product/service/ProductService.java
@@ -2,8 +2,8 @@ package com.harmoni.frontapi.main.product.service;
 
 import com.harmoni.frontapi.main.common.FrontApiGenericResponse;
 import com.harmoni.frontapi.main.common.ResponsePayload;
-import com.harmoni.frontapi.main.product.service.dao.ProductDao;
-import com.harmoni.frontapi.main.product.service.model.Product;
+import com.harmoni.frontapi.main.product.dao.ProductDao;
+import com.harmoni.frontapi.main.product.model.Product;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 

--- a/frontapi/src/main/java/com/harmoni/frontapi/main/transaction/controller/TransactionController.java
+++ b/frontapi/src/main/java/com/harmoni/frontapi/main/transaction/controller/TransactionController.java
@@ -3,7 +3,7 @@ package com.harmoni.frontapi.main.transaction.controller;
 import com.harmoni.frontapi.main.common.FrontApiGenericResponse;
 import com.harmoni.frontapi.main.common.ResponsePayload;
 import com.harmoni.frontapi.main.transaction.service.TransactionService;
-import com.harmoni.frontapi.main.transaction.service.model.Transaction;
+import com.harmoni.frontapi.main.transaction.model.Transaction;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/frontapi/src/main/java/com/harmoni/frontapi/main/transaction/dao/DevTransactionDaoService.java
+++ b/frontapi/src/main/java/com/harmoni/frontapi/main/transaction/dao/DevTransactionDaoService.java
@@ -1,6 +1,6 @@
-package com.harmoni.frontapi.main.transaction.service.dao;
+package com.harmoni.frontapi.main.transaction.dao;
 
-import com.harmoni.frontapi.main.transaction.service.model.Transaction;
+import com.harmoni.frontapi.main.transaction.model.Transaction;
 import org.springframework.stereotype.Repository;
 
 import java.util.ArrayList;

--- a/frontapi/src/main/java/com/harmoni/frontapi/main/transaction/dao/TransactionDao.java
+++ b/frontapi/src/main/java/com/harmoni/frontapi/main/transaction/dao/TransactionDao.java
@@ -1,6 +1,6 @@
-package com.harmoni.frontapi.main.transaction.service.dao;
+package com.harmoni.frontapi.main.transaction.dao;
 
-import com.harmoni.frontapi.main.transaction.service.model.Transaction;
+import com.harmoni.frontapi.main.transaction.model.Transaction;
 
 import java.util.List;
 import java.util.UUID;

--- a/frontapi/src/main/java/com/harmoni/frontapi/main/transaction/model/PaymentMethod.java
+++ b/frontapi/src/main/java/com/harmoni/frontapi/main/transaction/model/PaymentMethod.java
@@ -1,4 +1,4 @@
-package com.harmoni.frontapi.main.transaction.service.model;
+package com.harmoni.frontapi.main.transaction.model;
 
 public enum PaymentMethod {
     CASH,

--- a/frontapi/src/main/java/com/harmoni/frontapi/main/transaction/model/Transaction.java
+++ b/frontapi/src/main/java/com/harmoni/frontapi/main/transaction/model/Transaction.java
@@ -1,4 +1,4 @@
-package com.harmoni.frontapi.main.transaction.service.model;
+package com.harmoni.frontapi.main.transaction.model;
 
 import com.harmoni.frontapi.main.customer.model.Customer;
 import lombok.*;

--- a/frontapi/src/main/java/com/harmoni/frontapi/main/transaction/model/TransactionItem.java
+++ b/frontapi/src/main/java/com/harmoni/frontapi/main/transaction/model/TransactionItem.java
@@ -1,4 +1,4 @@
-package com.harmoni.frontapi.main.transaction.service.model;
+package com.harmoni.frontapi.main.transaction.model;
 
 import com.harmoni.frontapi.main.product.model.Product;
 import lombok.*;

--- a/frontapi/src/main/java/com/harmoni/frontapi/main/transaction/service/TransactionService.java
+++ b/frontapi/src/main/java/com/harmoni/frontapi/main/transaction/service/TransactionService.java
@@ -2,8 +2,8 @@ package com.harmoni.frontapi.main.transaction.service;
 
 import com.harmoni.frontapi.main.common.FrontApiGenericResponse;
 import com.harmoni.frontapi.main.common.ResponsePayload;
-import com.harmoni.frontapi.main.transaction.service.dao.TransactionDao;
-import com.harmoni.frontapi.main.transaction.service.model.Transaction;
+import com.harmoni.frontapi.main.transaction.dao.TransactionDao;
+import com.harmoni.frontapi.main.transaction.model.Transaction;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 

--- a/frontapi/src/main/java/com/harmoni/frontapi/main/transaction/service/model/Transaction.java
+++ b/frontapi/src/main/java/com/harmoni/frontapi/main/transaction/service/model/Transaction.java
@@ -1,6 +1,6 @@
 package com.harmoni.frontapi.main.transaction.service.model;
 
-import com.harmoni.frontapi.main.customer.service.model.Customer;
+import com.harmoni.frontapi.main.customer.model.Customer;
 import lombok.*;
 
 import java.time.LocalDateTime;

--- a/frontapi/src/main/java/com/harmoni/frontapi/main/transaction/service/model/TransactionItem.java
+++ b/frontapi/src/main/java/com/harmoni/frontapi/main/transaction/service/model/TransactionItem.java
@@ -1,6 +1,6 @@
 package com.harmoni.frontapi.main.transaction.service.model;
 
-import com.harmoni.frontapi.main.product.service.model.Product;
+import com.harmoni.frontapi.main.product.model.Product;
 import lombok.*;
 
 @AllArgsConstructor

--- a/frontapi/src/main/java/com/harmoni/frontapi/main/user/controller/UserController.java
+++ b/frontapi/src/main/java/com/harmoni/frontapi/main/user/controller/UserController.java
@@ -3,7 +3,7 @@ package com.harmoni.frontapi.main.user.controller;
 import com.harmoni.frontapi.main.common.FrontApiGenericResponse;
 import com.harmoni.frontapi.main.common.ResponsePayload;
 import com.harmoni.frontapi.main.user.service.UserService;
-import com.harmoni.frontapi.main.user.service.model.User;
+import com.harmoni.frontapi.main.user.model.User;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.NonNull;

--- a/frontapi/src/main/java/com/harmoni/frontapi/main/user/dao/DevUserDaoService.java
+++ b/frontapi/src/main/java/com/harmoni/frontapi/main/user/dao/DevUserDaoService.java
@@ -1,6 +1,6 @@
-package com.harmoni.frontapi.main.user.service.dao;
+package com.harmoni.frontapi.main.user.dao;
 
-import com.harmoni.frontapi.main.user.service.model.User;
+import com.harmoni.frontapi.main.user.model.User;
 import jakarta.annotation.Nullable;
 import org.springframework.stereotype.Repository;
 

--- a/frontapi/src/main/java/com/harmoni/frontapi/main/user/dao/UserDao.java
+++ b/frontapi/src/main/java/com/harmoni/frontapi/main/user/dao/UserDao.java
@@ -1,7 +1,7 @@
-package com.harmoni.frontapi.main.user.service.dao;
+package com.harmoni.frontapi.main.user.dao;
 
 
-import com.harmoni.frontapi.main.user.service.model.User;
+import com.harmoni.frontapi.main.user.model.User;
 import jakarta.annotation.Nullable;
 
 import java.util.List;

--- a/frontapi/src/main/java/com/harmoni/frontapi/main/user/model/Role.java
+++ b/frontapi/src/main/java/com/harmoni/frontapi/main/user/model/Role.java
@@ -1,4 +1,4 @@
-package com.harmoni.frontapi.main.user.service.model;
+package com.harmoni.frontapi.main.user.model;
 
 public enum Role {
     ADMIN, 

--- a/frontapi/src/main/java/com/harmoni/frontapi/main/user/model/User.java
+++ b/frontapi/src/main/java/com/harmoni/frontapi/main/user/model/User.java
@@ -1,4 +1,4 @@
-package com.harmoni.frontapi.main.user.service.model;
+package com.harmoni.frontapi.main.user.model;
 
 import lombok.*;
 

--- a/frontapi/src/main/java/com/harmoni/frontapi/main/user/service/UserService.java
+++ b/frontapi/src/main/java/com/harmoni/frontapi/main/user/service/UserService.java
@@ -2,8 +2,8 @@ package com.harmoni.frontapi.main.user.service;
 
 import com.harmoni.frontapi.main.common.FrontApiGenericResponse;
 import com.harmoni.frontapi.main.common.ResponsePayload;
-import com.harmoni.frontapi.main.user.service.dao.UserDao;
-import com.harmoni.frontapi.main.user.service.model.User;
+import com.harmoni.frontapi.main.user.dao.UserDao;
+import com.harmoni.frontapi.main.user.model.User;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 


### PR DESCRIPTION
- moved dao/model to module root
- tested by running `./frontapi` locally
   ![image](https://github.com/user-attachments/assets/bbe51761-5bda-4ad1-b950-079e1a1ded78)
